### PR TITLE
only show a scrollbar in the dropdown when any content is clipped

### DIFF
--- a/src/css/ng-dropdown.css
+++ b/src/css/ng-dropdown.css
@@ -61,7 +61,7 @@
   width: 100%;
   position: absolute;
   float: left;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   max-height: 200px;
   z-index: 999;


### PR DESCRIPTION
To prevent this:
![image](https://cloud.githubusercontent.com/assets/2564272/3032459/0297393c-e058-11e3-8226-82ab82d04af5.png)
